### PR TITLE
[dynamo] device-agnostic stream capture in dynamo

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -171,6 +171,26 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 9)
 
+    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    def test_cuda_stream_context_manager1(self):
+        def fn(x, s):
+            x = torch.mul(x, 5)
+            x = torch.add(x, 2)
+            with torch.cuda.stream(s):
+                x = torch.relu(x)
+            x = torch.add(x, 1)
+            x = torch.cos(x)
+            return x
+
+        x = torch.randn((2, 2))
+        s = torch.cuda.Stream()
+        ref = fn(x, s)
+        cnts = torch._dynamo.testing.CompileCounter()
+        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
+        res = opt_fn(x)
+        self.assertTrue(same(ref, res))
+        self.assertEqual(cnts.frame_count, 1)
+        self.assertEqual(cnts.op_count, 7)
 
     def test_autograd_profiler_enabled(self):
         def fn(x):

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -178,6 +178,15 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             x = torch.add(x, 2)
             with torch.cuda.stream(s):
                 x = torch.relu(x)
+
+            s1 = torch.cuda.current_stream()
+            with torch.cuda.stream(s1):
+                x = torch.relu(x)
+
+            s2 = torch.cuda.Stream()
+            with torch.cuda.stream(s2):
+                x = torch.relu(x)
+
             x = torch.add(x, 1)
             x = torch.cos(x)
             return x
@@ -190,7 +199,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x, s)
         self.assertTrue(same(ref, res))
         self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 8)
+        self.assertEqual(cnts.op_count, 18)
 
     def test_autograd_profiler_enabled(self):
         def fn(x):

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -172,7 +172,7 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.op_count, 9)
 
     @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager1(self):
+    def test_cuda_stream_context_manager2(self):
         def fn(x, s):
             x = torch.mul(x, 5)
             x = torch.add(x, 2)

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -171,27 +171,6 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(cnts.frame_count, 1)
         self.assertEqual(cnts.op_count, 9)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager2(self):
-        def fn(x, s):
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-            with torch.cuda.stream(s):
-                x = torch.relu(x)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2))
-        s = torch.cuda.Stream()
-        ref = fn(x, s)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "CUDAStreamVariable does not currently work soundly.",
-        ):
-            res = opt_fn(x, s)
 
     def test_autograd_profiler_enabled(self):
         def fn(x):

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -187,10 +187,10 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         ref = fn(x, s)
         cnts = torch._dynamo.testing.CompileCounter()
         opt_fn = torch._dynamo.optimize(cnts, nopython=True)(fn)
-        res = opt_fn(x)
+        res = opt_fn(x, s)
         self.assertTrue(same(ref, res))
         self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 7)
+        self.assertEqual(cnts.op_count, 8)
 
     def test_autograd_profiler_enabled(self):
         def fn(x):

--- a/torch/_dynamo/stream.py
+++ b/torch/_dynamo/stream.py
@@ -1,5 +1,6 @@
 import torch
 import torch.cuda
+import warnings
 
 
 def __singleton(cls):
@@ -12,17 +13,11 @@ def __singleton(cls):
     return get_instance
 
 
+# This class is used to contain the provided stream methods for dynamo to 
+# capture the stream usage.
 @__singleton
 class StreamMethodContainer:
     def __init__(self) -> None:
-        '''
-        containers to mantain the cuda methods:
-        set_stream_method: {'cuda': [torch.cuda.set_stream]}
-        set_stream_by_id_method: {'cuda': [torch.cuda.set_stream_by_id]}
-        current_stream_method: {'cuda': [torch.cuda.current_stream]}
-        create_stream_method: {'cuda': [torch.cuda.streams.Stream]}
-        create_stream_context_method: {'cuda': [torch.cuda.stream]}
-        '''
         self.current_stream_method = {}
         self.create_stream_method = {}
         self.create_stream_context_method = {}
@@ -40,19 +35,20 @@ class StreamMethodContainer:
         if device not in getattr(self, container).keys():
             getattr(self, container)[device] = []
         for method in method_args:
-            if method is not None:
-                getattr(self, container)[device].append(method)
+            getattr(self, container)[device].append(method)
 
 
     def __get(self, container: str, device: str):
-        assert hasattr(self, container), "unknown container to get stream methods"
-        assert device in getattr(self, container).keys(), "unknown device to get stream methods"
-        assert len(getattr(self, container)[device]) == 1, "ambiguous functions for this method"
+        assert device in getattr(self, container).keys(), "unknown device {device}"
+        assert len(getattr(self, container)[device]) == 1, "ambiguous methods found for {container} and {device}"
+        if getattr(self, container)[device][0] is None:
+            warnings.warn(
+                "get a None method for " + container + " and " + device
+            )
         return getattr(self, container)[device][0]
 
 
     def __get_all(self, container: str) -> list:
-        assert hasattr(self, container), "unknown container to get stream methods"
         ret_method = []
         for device_key in getattr(self, container).keys():
             ret_method.append(getattr(self, container)[device_key][0])
@@ -64,7 +60,12 @@ class StreamMethodContainer:
 
 
     def get_all_methods(self, container: str):
-        return self.__get_all(container)
+        if container in [
+            'set_stream', 'set_stream_by_id', 'current_stream', 'create_stream', 'create_stream_context'
+        ]:
+            return self.__get_all(container + '_method')
+        else:
+            raise RuntimeError(f"Unknown stream method '{container}'")
 
 
     def get_method_by_device(self, container: str, device: str):
@@ -74,6 +75,8 @@ class StreamMethodContainer:
 StreamMethodObject = StreamMethodContainer()
 
 
+# Here are some APIs for developers to resgiter their stream methods, which are needed to 
+# align with the specific semantics.
 def register_current_stream_method(device: str, *method_args):
     StreamMethodObject.register_stream_method('current_stream_method', device, method_args)
 
@@ -94,8 +97,18 @@ def register_set_stream_by_id_method(device: str, *method_args):
     StreamMethodObject.register_stream_method('set_stream_by_id_method', device, method_args)
 
 
+# For backend developers, it is needed to register their stream usage by using:
+# 
+# * torch._dynamo.stream.register_current_stream_method(device, stream_method)
+# 
+# the stream_method is needed to align the semantics of torch.cuda.current_stream,
+# which returns a current using stream.
+# If there is no such method, please explicitly register None
+#
+# * torch._dynamo.stream.register_current_stream_method(device, None)
+#
+# Here register 5 CUDA stream methods for stream capture in dynamo
 if torch.cuda.is_available():
-    # register stream API for dynamo stream capture
     register_current_stream_method('cuda', torch.cuda.current_stream)
     register_create_stream_method('cuda', torch.cuda.streams.Stream)
     register_create_stream_context_method('cuda', torch.cuda.stream)

--- a/torch/_dynamo/stream.py
+++ b/torch/_dynamo/stream.py
@@ -16,6 +16,7 @@ def __singleton(cls):
 class StreamMethodContainer:
     def __init__(self) -> None:
         '''
+        containers to mantain the cuda methods:
         set_stream_method: {'cuda': [torch.cuda.set_stream]}
         set_stream_by_id_method: {'cuda': [torch.cuda.set_stream_by_id]}
         current_stream_method: {'cuda': [torch.cuda.current_stream]}
@@ -58,24 +59,8 @@ class StreamMethodContainer:
         return ret_method
 
 
-    def register_current_stream_method(self, device: str, *method_args):
-        self.__register('current_stream_method', device, method_args)
-
-
-    def register_create_stream_method(self, device: str, *method_args):
-        self.__register('create_stream_method', device, method_args)
-
-
-    def register_create_stream_context_method(self, device: str, *method_args):
-        self.__register('create_stream_context_method', device, method_args)
-
-
-    def register_set_stream_method(self, device: str, *method_args):
-        self.__register('set_stream_method', device, method_args)
-
-
-    def register_set_stream_by_id_method(self, device: str, *method_args):
-        self.__register('set_stream_by_id_method', device, method_args)
+    def register_stream_method(self, container: str, device: str, *method_args):
+        self.__register(container, device, method_args)
 
 
     def get_all_methods(self, container: str):
@@ -86,11 +71,33 @@ class StreamMethodContainer:
         return self.__get(container, device)
 
 
+StreamMethodObject = StreamMethodContainer()
+
+
+def register_current_stream_method(device: str, *method_args):
+    StreamMethodObject.register_stream_method('current_stream_method', device, method_args)
+
+
+def register_create_stream_method(device: str, *method_args):
+    StreamMethodObject.register_stream_method('create_stream_method', device, method_args)
+
+
+def register_create_stream_context_method(device: str, *method_args):
+    StreamMethodObject.register_stream_method('create_stream_context_method', device, method_args)
+
+
+def register_set_stream_method(device: str, *method_args):
+    StreamMethodObject.register_stream_method('set_stream_method', device, method_args)
+
+
+def register_set_stream_by_id_method(device: str, *method_args):
+    StreamMethodObject.register_stream_method('set_stream_by_id_method', device, method_args)
+
+
 if torch.cuda.is_available():
     # register stream API for dynamo stream capture
-    StreamAPIObject = StreamMethodContainer()
-    StreamAPIObject.register_create_stream_method('cuda', torch.cuda.streams.Stream)
-    StreamAPIObject.register_create_stream_context_method('cuda', torch.cuda.stream)
-    StreamAPIObject.register_current_stream_method('cuda', torch.cuda.current_stream)
-    StreamAPIObject.register_set_stream_method('cuda', torch.cuda.set_stream)
-    StreamAPIObject.register_set_stream_by_id_method('cuda', torch.cuda.set_stream_by_id)
+    register_current_stream_method('cuda', torch.cuda.current_stream)
+    register_create_stream_method('cuda', torch.cuda.streams.Stream)
+    register_create_stream_context_method('cuda', torch.cuda.stream)
+    register_set_stream_method('cuda', torch.cuda.set_stream)
+    register_set_stream_by_id_method('cuda', torch.cuda.set_stream_by_id)

--- a/torch/_dynamo/stream.py
+++ b/torch/_dynamo/stream.py
@@ -1,0 +1,116 @@
+import torch
+import torch.cuda
+
+
+def __singleton(cls):
+    instance = {}
+    def get_instance(*args, **kwargs):
+        if cls not in instance:
+            instance[cls] = cls(*args, **kwargs)
+        return instance[cls]
+    return get_instance
+
+
+@__singleton
+class StreamAPIContainer:
+    def __init__(self) -> None:
+        '''
+        set_stream_method: {'cuda': [torch.cuda.set_stream]}
+        set_stream_by_id_method: {'cuda': [torch.cuda.set_stream_by_id]}
+        current_stream_method: {'cuda': [torch.cuda.current_stream]}
+        create_stream_method: {'cuda': [torch.cuda.streams.Stream]}
+        create_stream_context_method: {'cuda': [torch.cuda.stream]}
+        '''
+        # {'cuda', torch.cuda.current_stream}
+        self.current_stream_method = {}
+        # {'cuda', torch.cuda.streams.Stream}
+        self.create_stream_method = {}
+        # {'cuda', torch.cuda.streams.Stream}
+        self.create_stream_context_method = {}
+        # {'cuda', torch.cuda.set_stream}
+        self.set_stream_method = {}
+        # {'cuda', torch.cuda.set_stream_by_id}
+        self.set_stream_by_id_method = {}
+
+
+    def __init_subclass__(cls):
+        raise TypeError("class StreamAPIContainer can not be inherited")
+
+
+    def __register(self, container: str, device: str, *method_args) -> None:
+        if len(method_args) <= 0:
+            return
+        if device not in getattr(self, container).keys():
+            getattr(self, container)[device] = []
+        for method in method_args:
+            if method is not None:
+                getattr(self, container)[device].append(method)
+
+
+    def __get(self, container: str, device: str):
+        assert device in getattr(self, container).keys(), "unknown device to get stream methods"
+        assert len(getattr(self, container)[device]) == 1, "ambiguous functions for this method"
+        return getattr(self, container)[device][0]
+
+
+    def __get_all(self, container: str) -> list:
+        ret_method = []
+        for device_key in getattr(self, container).keys():
+            ret_method.append(getattr(self, container)[device_key])
+        return ret_method
+
+
+    def register_current_stream_method(self, device: str, *method_args):
+        self.__register('current_stream_method', device, method_args)
+
+
+    def register_create_stream_method(self, device: str, *method_args):
+        self.__register('create_stream_method', device, method_args)
+
+
+    def register_create_stream_context_method(self, device: str, *method_args):
+        self.__register('create_stream_context_method', device, method_args)
+
+
+    def register_set_stream_method(self, device: str, *method_args):
+        self.__register('set_stream_method', device, method_args)
+
+
+    def register_set_stream_by_id_method(self, device: str, *method_args):
+        self.__register('set_stream_by_id_method', device, method_args)
+
+
+    def get_all_current_stream_method(self):
+        return self.__get_all('current_stream_method')
+
+
+    def get_all_create_stream_method(self):
+        return self.__get_all('create_stream_method')
+
+
+    def get_all_create_stream_context_method(self):
+        return self.__get_all('create_stream_context_method')
+
+
+    def get_all_set_stream_method(self):
+        return self.__get('set_stream_method')
+
+
+    def get_current_stream_method(self, device: str):
+        return self.__get('current_stream_method', device)
+
+
+    def get_create_stream_method(self, device: str):
+        return self.__get('create_stream_method', device)
+
+
+    def get_create_stream_context_method(self, device: str):
+        return self.__get('create_stream_context_method', device)
+
+
+    def get_set_stream_method(self, device: str):
+        return self.__get('set_stream_method', device)
+
+
+    def get_set_stream_by_id_method(self, device: str):
+        return self.__get('set_stream_by_id_method', device)

--- a/torch/_dynamo/stream.py
+++ b/torch/_dynamo/stream.py
@@ -4,6 +4,7 @@ import torch.cuda
 
 def __singleton(cls):
     instance = {}
+
     def get_instance(*args, **kwargs):
         if cls not in instance:
             instance[cls] = cls(*args, **kwargs)
@@ -12,7 +13,7 @@ def __singleton(cls):
 
 
 @__singleton
-class StreamAPIContainer:
+class StreamMethodContainer:
     def __init__(self) -> None:
         '''
         set_stream_method: {'cuda': [torch.cuda.set_stream]}
@@ -21,23 +22,18 @@ class StreamAPIContainer:
         create_stream_method: {'cuda': [torch.cuda.streams.Stream]}
         create_stream_context_method: {'cuda': [torch.cuda.stream]}
         '''
-        # {'cuda', torch.cuda.current_stream}
         self.current_stream_method = {}
-        # {'cuda', torch.cuda.streams.Stream}
         self.create_stream_method = {}
-        # {'cuda', torch.cuda.streams.Stream}
         self.create_stream_context_method = {}
-        # {'cuda', torch.cuda.set_stream}
         self.set_stream_method = {}
-        # {'cuda', torch.cuda.set_stream_by_id}
         self.set_stream_by_id_method = {}
 
 
     def __init_subclass__(cls):
-        raise TypeError("class StreamAPIContainer can not be inherited")
+        raise TypeError("class StreamMethodContainer can not be inherited")
 
 
-    def __register(self, container: str, device: str, *method_args) -> None:
+    def __register(self, container: str, device: str, method_args) -> None:
         if len(method_args) <= 0:
             return
         if device not in getattr(self, container).keys():
@@ -48,15 +44,17 @@ class StreamAPIContainer:
 
 
     def __get(self, container: str, device: str):
+        assert hasattr(self, container), "unknown container to get stream methods"
         assert device in getattr(self, container).keys(), "unknown device to get stream methods"
         assert len(getattr(self, container)[device]) == 1, "ambiguous functions for this method"
         return getattr(self, container)[device][0]
 
 
     def __get_all(self, container: str) -> list:
+        assert hasattr(self, container), "unknown container to get stream methods"
         ret_method = []
         for device_key in getattr(self, container).keys():
-            ret_method.append(getattr(self, container)[device_key])
+            ret_method.append(getattr(self, container)[device_key][0])
         return ret_method
 
 
@@ -80,37 +78,19 @@ class StreamAPIContainer:
         self.__register('set_stream_by_id_method', device, method_args)
 
 
-    def get_all_current_stream_method(self):
-        return self.__get_all('current_stream_method')
+    def get_all_methods(self, container: str):
+        return self.__get_all(container)
 
 
-    def get_all_create_stream_method(self):
-        return self.__get_all('create_stream_method')
+    def get_one_method(self, container: str, device: str):
+        return self.__get(container, device)
 
 
-    def get_all_create_stream_context_method(self):
-        return self.__get_all('create_stream_context_method')
-
-
-    def get_all_set_stream_method(self):
-        return self.__get('set_stream_method')
-
-
-    def get_current_stream_method(self, device: str):
-        return self.__get('current_stream_method', device)
-
-
-    def get_create_stream_method(self, device: str):
-        return self.__get('create_stream_method', device)
-
-
-    def get_create_stream_context_method(self, device: str):
-        return self.__get('create_stream_context_method', device)
-
-
-    def get_set_stream_method(self, device: str):
-        return self.__get('set_stream_method', device)
-
-
-    def get_set_stream_by_id_method(self, device: str):
-        return self.__get('set_stream_by_id_method', device)
+if torch.cuda.is_available():
+    # register stream API for dynamo stream capture
+    StreamAPIObject = StreamMethodContainer()
+    StreamAPIObject.register_create_stream_method('cuda', torch.cuda.streams.Stream)
+    StreamAPIObject.register_create_stream_context_method('cuda', torch.cuda.stream)
+    StreamAPIObject.register_current_stream_method('cuda', torch.cuda.current_stream)
+    StreamAPIObject.register_set_stream_method('cuda', torch.cuda.set_stream)
+    StreamAPIObject.register_set_stream_by_id_method('cuda', torch.cuda.set_stream_by_id)

--- a/torch/_dynamo/stream.py
+++ b/torch/_dynamo/stream.py
@@ -45,7 +45,7 @@ class StreamMethodContainer:
         return ret_method
 
 
-    def __register_stream_method(self, container: str, device: str, method):
+    def register_stream_method(self, container: str, device: str, method):
         getattr(self, container)[device] = method
 
 
@@ -59,7 +59,7 @@ class StreamMethodContainer:
 
 
     def get_method_by_device(self, container: str, device: str):
-        return self.__get(container, device)
+        return self.__get(container + '_method', device)
 
 
 # the global instance to contain the stream methods
@@ -70,7 +70,7 @@ StreamMethodObject = StreamMethodContainer()
 # align with the specific semantics.
 def register_stream_method(device: str, method_args_dict: dict):
     for key in method_args_dict.keys():
-        StreamMethodObject.__register_stream_method(key + '_method', device, method_args_dict[key])
+        StreamMethodObject.register_stream_method(key + '_method', device, method_args_dict[key])
 
 
 # A dict with specific semantics and associated method is required for register.

--- a/torch/_dynamo/stream.py
+++ b/torch/_dynamo/stream.py
@@ -59,7 +59,7 @@ class StreamMethodContainer:
         return ret_method
 
 
-    def register_stream_method(self, container: str, device: str, *method_args):
+    def register_stream_method(self, container: str, device: str, method_args):
         self.__register(container, device, method_args)
 
 
@@ -67,7 +67,7 @@ class StreamMethodContainer:
         return self.__get_all(container)
 
 
-    def get_one_method(self, container: str, device: str):
+    def get_method_by_device(self, container: str, device: str):
         return self.__get(container, device)
 
 

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -3,8 +3,8 @@ from .builtin import BuiltinVariable
 from .constant import ConstantVariable, EnumVariable
 from .ctx_manager import (
     ContextWrappingVariable,
-    CUDAStreamContextVariable,
-    CUDAStreamVariable,
+    StreamContextVariable,
+    StreamVariable,
     DeterministicAlgorithmsVariable,
     DisabledSavedTensorsHooksVariable,
     GradModeVariable,

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -566,8 +566,8 @@ class VariableBuilder:
                 value,
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )
-        elif any([isinstance(value, stream_instance) for stream_instance in 
-            StreamMethodContainer().get_all_methods('create_stream')]
+        elif any(
+            [isinstance(value, stream_instance) for stream_instance in StreamMethodContainer().get_all_methods('stream_class')]
         ):
             return StreamVariable(
                 None,
@@ -1336,8 +1336,8 @@ def wrap_fx_proxy_cls(
     elif isinstance(example_value, (torch.SymInt, torch.SymFloat, torch.SymBool)):
         proxy.node.meta["example_value"] = example_value
         return SymNodeVariable(proxy, example_value, **options)
-    elif proxy.node.target in StreamMethodContainer().get_all_methods('create_stream') or \
-        proxy.node.target in StreamMethodContainer().get_all_methods('current_stream'):
+    elif proxy.node.target in StreamMethodContainer().get_all_methods('stream_class') or \
+            proxy.node.target in StreamMethodContainer().get_all_methods('current_stream'):
         proxy.node.meta["example_value"] = example_value
         return StreamVariable(proxy, example_value, example_value.device.type, **options)
     elif isinstance(example_value, int) and proxy.node.target in [

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -567,7 +567,7 @@ class VariableBuilder:
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )
         elif any([isinstance(value, stream_instance) for stream_instance in 
-            StreamMethodContainer().get_all_methods('create_stream_method')]
+            StreamMethodContainer().get_all_methods('create_stream')]
         ):
             return StreamVariable(
                 None,
@@ -1336,8 +1336,8 @@ def wrap_fx_proxy_cls(
     elif isinstance(example_value, (torch.SymInt, torch.SymFloat, torch.SymBool)):
         proxy.node.meta["example_value"] = example_value
         return SymNodeVariable(proxy, example_value, **options)
-    elif proxy.node.target in StreamMethodContainer().get_all_methods('create_stream_method') or \
-        proxy.node.target in StreamMethodContainer().get_all_methods('current_stream_method'):
+    elif proxy.node.target in StreamMethodContainer().get_all_methods('create_stream') or \
+        proxy.node.target in StreamMethodContainer().get_all_methods('current_stream'):
         proxy.node.meta["example_value"] = example_value
         return StreamVariable(proxy, example_value, example_value.device.type, **options)
     elif isinstance(example_value, int) and proxy.node.target in [

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -26,7 +26,7 @@ from torch.fx.immutable_collections import immutable_list
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 from torch.utils.weak import TensorWeakRef, WeakIdRef
 
-from ..stream import StreamAPIContainer
+from ..stream import StreamMethodContainer
 from .. import config, mutation_guard, replay_record, skipfiles
 from ..allowed_functions import is_allowed, is_builtin_callable, is_numpy
 from ..exc import unimplemented
@@ -567,7 +567,7 @@ class VariableBuilder:
                 guards=make_guards(GuardBuilder.FUNCTION_MATCH),
             )
         elif any([isinstance(value, stream_instance) for stream_instance in 
-            StreamAPIContainer().get_all_create_stream_method()]
+            StreamMethodContainer().get_all_methods('create_stream_method')]
         ):
             return StreamVariable(
                 None,
@@ -1336,8 +1336,8 @@ def wrap_fx_proxy_cls(
     elif isinstance(example_value, (torch.SymInt, torch.SymFloat, torch.SymBool)):
         proxy.node.meta["example_value"] = example_value
         return SymNodeVariable(proxy, example_value, **options)
-    elif proxy.node.target in StreamAPIContainer().get_all_create_stream_method() or \
-        proxy.node.target in StreamAPIContainer().get_all_current_stream_method():
+    elif proxy.node.target in StreamMethodContainer().get_all_methods('create_stream_method') or \
+        proxy.node.target in StreamMethodContainer().get_all_methods('current_stream_method'):
         proxy.node.meta["example_value"] = example_value
         return StreamVariable(proxy, example_value, example_value.device.type, **options)
     elif isinstance(example_value, int) and proxy.node.target in [

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -66,7 +66,7 @@ from ..utils import (
 from .base import MutableLocal, typestr, VariableTracker
 from .builtin import BuiltinVariable
 from .constant import ConstantVariable, EnumVariable
-from .ctx_manager import StreamVariable, NullContextVariable, StreamContextVariable
+from .ctx_manager import StreamVariable, NullContextVariable
 from .dicts import (
     ConstDictVariable,
     DataClassVariable,

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -363,7 +363,7 @@ class StreamContextVariable(ContextWrappingVariable):
     @staticmethod
     def create(tx, target_value, **kwargs):
         from .builder import wrap_fx_proxy_cls
-        current_stream_method = StreamMethodContainer().get_method_by_device('current_stream_method', target_value.device)
+        current_stream_method = StreamMethodContainer().get_method_by_device('current_stream', target_value.device)
         current_stream = wrap_fx_proxy_cls(
             StreamVariable,
             tx,
@@ -386,7 +386,7 @@ class StreamContextVariable(ContextWrappingVariable):
             target_values=target_values, initial_values=initial_values, **kwargs
         )
         self.device = device
-        self.set_stream_func = StreamMethodContainer().get_method_by_device('set_stream_method', self.device)
+        self.set_stream_func = StreamMethodContainer().get_method_by_device('set_stream', self.device)
 
     def enter(self, tx):
         # stream generated inside of traced function
@@ -402,11 +402,11 @@ class StreamContextVariable(ContextWrappingVariable):
             stream = self.target_values[0].value
             tx.output.create_proxy(
                 "call_function",
-                StreamMethodContainer().get_method_by_device('set_stream_by_id_method', self.device),
+                StreamMethodContainer().get_method_by_device('set_stream_by_id', self.device),
                 (stream.stream_id, stream.device_index, stream.device_type),
                 {},
             )
-        StreamMethodContainer().get_method_by_device('set_stream_method', self.device)(self.target_values[0].value)
+        StreamMethodContainer().get_method_by_device('set_stream', self.device)(self.target_values[0].value)
 
     def exit(self, tx, *args):
         tx.output.create_proxy(

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -428,7 +428,7 @@ class StreamVariable(VariableTracker):
     def __init__(self, proxy, value, device, **kwargs):
         if proxy is not None and "example_value" in proxy.node.meta:
             assert proxy.node.meta["example_value"] == value
-        assert value.device.type == device, f"stream value is not equal to the passed device"
+        assert value.device.type == device, "stream value is not equal to the passed device"
         super().__init__(**kwargs)
         self.proxy = proxy
         self.value = value

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -363,7 +363,7 @@ class StreamContextVariable(ContextWrappingVariable):
     @staticmethod
     def create(tx, target_value, **kwargs):
         from .builder import wrap_fx_proxy_cls
-        current_stream_method = StreamMethodContainer().get_one_method('current_stream_method', target_value.device)
+        current_stream_method = StreamMethodContainer().get_method_by_device('current_stream_method', target_value.device)
         current_stream = wrap_fx_proxy_cls(
             StreamVariable,
             tx,
@@ -386,7 +386,7 @@ class StreamContextVariable(ContextWrappingVariable):
             target_values=target_values, initial_values=initial_values, **kwargs
         )
         self.device = device
-        self.set_stream_func = StreamMethodContainer().get_one_method('set_stream_method', self.device)
+        self.set_stream_func = StreamMethodContainer().get_method_by_device('set_stream_method', self.device)
 
     def enter(self, tx):
         # stream generated inside of traced function
@@ -402,11 +402,11 @@ class StreamContextVariable(ContextWrappingVariable):
             stream = self.target_values[0].value
             tx.output.create_proxy(
                 "call_function",
-                StreamMethodContainer().get_one_method('set_stream_by_id_method', self.device),
+                StreamMethodContainer().get_method_by_device('set_stream_by_id_method', self.device),
                 (stream.stream_id, stream.device_index, stream.device_type),
                 {},
             )
-        StreamMethodContainer().get_one_method('set_stream_method', self.device)(self.target_values[0].value)
+        StreamMethodContainer().get_method_by_device('set_stream_method', self.device)(self.target_values[0].value)
 
     def exit(self, tx, *args):
         tx.output.create_proxy(

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -399,11 +399,9 @@ class StreamContextVariable(ContextWrappingVariable):
         # stream passed from outside of traced function
         else:
             stream = self.target_values[0].value
-            # TODO: here could be a problem because ipex._C cannot be called
-            # and torch._C does not contain any xpu function
             tx.output.create_proxy(
                 "call_function",
-                getattr(torch._C, '_' + str(self.device) + '_setStream'),
+                getattr(getattr(torch, self.device), '_set_stream'),
                 (stream.stream_id, stream.device_index, stream.device_type),
                 {},
             )

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -332,7 +332,7 @@ class TorchVariable(VariableTracker):
             return TorchFunctionDisableVariable.create(tx, **options)
         elif any(
             [self.value is method for method in
-             StreamMethodContainer().get_all_methods('create_stream_context_method')]
+             StreamMethodContainer().get_all_methods('create_stream_context')]
         ):
             log.warning(
                 str(StreamMethodContainer().get_method_by_device('create_stream_context_method', args[0].device)) +
@@ -342,7 +342,7 @@ class TorchVariable(VariableTracker):
             return StreamContextVariable.create(tx, args[0], **options)
         elif any(
             [self.value is method for method in
-             StreamMethodContainer().get_all_methods('create_stream_method')]
+             StreamMethodContainer().get_all_methods('create_stream')]
         ):
             match_device = None
             for device, method in StreamMethodContainer().create_stream_method.items():

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -342,10 +342,10 @@ class TorchVariable(VariableTracker):
             return StreamContextVariable.create(tx, args[0], **options)
         elif any(
             [self.value is method for method in
-             StreamMethodContainer().get_all_methods('create_stream')]
+             StreamMethodContainer().get_all_methods('stream_class')]
         ):
             match_device = None
-            for device, method in StreamMethodContainer().create_stream_method.items():
+            for device, method in StreamMethodContainer().stream_class.items():
                 if self.value is method[0]:
                     match_device = device
             return wrap_fx_proxy_cls(
@@ -353,7 +353,7 @@ class TorchVariable(VariableTracker):
                 tx,
                 tx.output.create_proxy(
                     "call_function",
-                    StreamMethodContainer().get_method_by_device('create_stream_method', match_device),
+                    StreamMethodContainer().get_method_by_device('stream_class', match_device),
                     (),
                     {},
                 ),

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -335,7 +335,7 @@ class TorchVariable(VariableTracker):
              StreamMethodContainer().get_all_methods('create_stream_context')]
         ):
             log.warning(
-                str(StreamMethodContainer().get_method_by_device('create_stream_context_method', args[0].device)) +
+                str(StreamMethodContainer().get_method_by_device('create_stream_context', args[0].device)) +
                 "not fully supported, streams may be ignored"
             )
             assert len(args) == 1
@@ -345,8 +345,8 @@ class TorchVariable(VariableTracker):
              StreamMethodContainer().get_all_methods('stream_class')]
         ):
             match_device = None
-            for device, method in StreamMethodContainer().stream_class.items():
-                if self.value is method[0]:
+            for device, method in StreamMethodContainer().stream_class_method.items():
+                if self.value is method:
                     match_device = device
             return wrap_fx_proxy_cls(
                 StreamVariable,

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -335,7 +335,7 @@ class TorchVariable(VariableTracker):
              StreamMethodContainer().get_all_methods('create_stream_context_method')]
         ):
             log.warning(
-                str(StreamMethodContainer().get_one_method('create_stream_context_method', args[0].device)) +
+                str(StreamMethodContainer().get_method_by_device('create_stream_context_method', args[0].device)) +
                 "not fully supported, streams may be ignored"
             )
             assert len(args) == 1
@@ -353,7 +353,7 @@ class TorchVariable(VariableTracker):
                 tx,
                 tx.output.create_proxy(
                     "call_function",
-                    StreamMethodContainer().get_one_method('create_stream_method', match_device),
+                    StreamMethodContainer().get_method_by_device('create_stream_method', match_device),
                     (),
                     {},
                 ),

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -329,37 +329,19 @@ class TorchVariable(VariableTracker):
         elif self.value is torch._C.DisableTorchFunctionSubclass:
             assert not (args or kwargs)
             return TorchFunctionDisableVariable.create(tx, **options)
-        elif self.value is torch.cuda.stream:
+        elif hasattr(self.value, '__name__') and self.value.__name__ == 'stream':
             log.warning(
-                "torch.cuda.stream() not fully supported, streams may be ignored"
+                "torch." + args[0].device + ".stream() not fully supported, streams may be ignored"
             )
             assert len(args) == 1
-            return StreamContextVariable.create(tx, args[0], 'cuda', **options)
-        elif self.value is torch.xpu.stream:
-            log.warning(
-                "torch.xpu.stream() not fully supported, streams may be ignored"
-            )
-            assert len(args) == 1
-            return StreamContextVariable.create(tx, args[0], 'xpu', **options)
-        elif self.value is torch.cuda.streams.Stream:
+            return StreamContextVariable.create(tx, args[0], **options)
+        elif hasattr(self.value, 'stream_id'):
             return wrap_fx_proxy_cls(
                 StreamVariable,
                 tx,
                 tx.output.create_proxy(
                     "call_function",
-                    torch.cuda.streams.Stream,
-                    (),
-                    {},
-                ),
-                **options,
-            )
-        elif self.value is torch.xpu.streams.Stream:
-            return wrap_fx_proxy_cls(
-                StreamVariable,
-                tx,
-                tx.output.create_proxy(
-                    "call_function",
-                    torch.xpu.streams.Stream,
+                    self.value,
                     (),
                     {},
                 ),

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -20,7 +20,6 @@ from typing import Any, cast, List, Optional, Tuple, Union
 
 import torch
 import torch._C
-from torch._dynamo.stream import StreamAPIContainer
 from torch.types import Device
 from .. import device as _device
 from .._utils import classproperty
@@ -561,7 +560,7 @@ def set_stream(stream: Stream):
     """
     if stream is None:
         return
-    _set_stream(
+    set_stream_by_id(
         stream_id=stream.stream_id,
         device_index=stream.device_index,
         device_type=stream.device_type,
@@ -1286,15 +1285,6 @@ def _register_triton_kernels():
 
 
 _lazy_call(_register_triton_kernels)
-
-
-# register stream API for dynamo stream capture
-StreamAPIObject = StreamAPIContainer()
-StreamAPIObject.register_create_stream_method('cuda', torch.cuda.streams.Stream)
-StreamAPIObject.register_create_stream_context_method('cuda', torch.cuda.stream)
-StreamAPIObject.register_current_stream_method('cuda', torch.cuda.current_stream)
-StreamAPIObject.register_set_stream_method('cuda', torch.cuda.set_stream)
-StreamAPIObject.register_set_stream_by_id_method('cuda', torch.cuda.set_stream_by_id)
 
 
 from . import amp, jiterator, nvtx, profiler, sparse

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -534,6 +534,21 @@ def stream(stream: Optional["torch.cuda.Stream"]) -> StreamContext:
     return StreamContext(stream)
 
 
+def _set_stream(stream_id, device_index, device_type):
+    r"""Native set stream specified by the stream id, device index and
+        device type
+
+    Args: stream_id (int): specific stream id
+          device_index (int): specific device id
+          device_type (string): specific device type
+    """
+    torch._C._cuda_setStream(
+        stream_id=stream_id,
+        device_index=device_index,
+        device_type=device_type,
+    )
+
+
 def set_stream(stream: Stream):
     r"""Sets the current stream.This is a wrapper API to set the stream.
         Usage of this function is discouraged in favor of the ``stream``
@@ -545,7 +560,7 @@ def set_stream(stream: Stream):
     """
     if stream is None:
         return
-    torch._C._cuda_setStream(
+    _set_stream(
         stream_id=stream.stream_id,
         device_index=stream.device_index,
         device_type=stream.device_type,


### PR DESCRIPTION
Here we implement a global singleton container named StreamMethodContainer for different backends to register their associated stream methods to dynamo. When import the backend’s product, the stream operations can be registered directly by calling torch._dynamo.stream.register_stream_method(device_name, device_stream_method). Stream methods need to be passed in this API according to the precise semantics represented by the dict key in device_stream_method. After register, these methods can be used by dynamo to capture the stream operations in users’ script, for example, get the current stream or set the specific stream. Additionally, the wrapped stream variable and the stream context variable are changed to be the device-agnostic, the proxy functions of these variables are assigned by the associated methods in the container. All of this are illustrated in the below.

1. Implement a container for backend product to register their associated stream methods.
2. Change the stream and stream context wrapper to be device-agnostic.


![image](https://github.com/zejun-chen/pytorch/assets/74231238/2bf19a2c-b95c-41d7-90c2-9377eedae2bf)
