### PR TITLE
[profiler] Directly use end_ns to create the FunctionEvent

### DIFF
--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -503,8 +503,8 @@ class profile:
             if _filter_name(kineto_event.name()):
                 continue
             rel_start_ns = kineto_event.start_ns() - trace_start_ns
-            rel_end_ns = rel_start_ns + kineto_event.duration_ns()
-            abs_end_ns = kineto_event.start_ns() + kineto_event.duration_ns()
+            rel_end_ns = kineto_event.end_ns() - trace_start_ns
+            abs_end_ns = kineto_event.end_ns()
 
             cpu_memory_usage = 0
             device_memory_usage = 0

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -203,6 +203,8 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def("sequence_nr", [](const KinetoEvent& e) { return e.sequenceNr(); })
       // absolute start time (since unix epoch) in ns
       .def("start_ns", [](const KinetoEvent& e) { return e.startNs(); })
+      // absolute end time (since unix epoch) in ns
+      .def("end_ns", [](const KinetoEvent& e) { return e.endNs(); })
       // duration in ns
       .def("duration_ns", [](const KinetoEvent& e) { return e.durationNs(); })
       // used for correlation between high-level PyTorch events

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -786,6 +786,10 @@ const c10::ArrayRef<std::string> KinetoEvent::moduleHierarchy() const {
   return {};
 }
 
+uint64_t KinetoEvent::endNs() const {
+  return result_->endTimeNS();
+}
+
 uint64_t KinetoEvent::durationNs() const {
   return (result_->endTimeNS() - result_->start_time_ns_);
 }

--- a/torch/csrc/autograd/profiler_kineto.h
+++ b/torch/csrc/autograd/profiler_kineto.h
@@ -49,6 +49,7 @@ struct TORCH_API KinetoEvent {
   int deviceIndex() const;
   int64_t nBytes() const;
   uint64_t startNs() const;
+  uint64_t endNs() const;
   uint64_t durationNs() const;
   bool isAsync() const;
   uint64_t correlationId() const;


### PR DESCRIPTION
Directly use end_ns to create the FunctionEvent instead of using start_ns + duration_ns in pytorch profiler post processing.
In previous torch code, the post processing was using US unit timestamp and NS to US in KinetoEvent::startUs and KinetoEvent::durationUs discarded the decimal part of the value. So for the accumulation(start_us + duration_us), the carry in accumulation sometimes was missed for the parent ops' end time. Thus, when populating the children in all events, there would be wrong parent-child pair because the parent's end time would be smaller than the child's end time for the lack of carry.
Finally, the negative cpu time happens because the grandparent op wrongly had 2 children, which should be 1 child and 1 grandchild in fact, then the grandparent's cpu time would be minus the parent's cpu time and grandchild's cpu time.
According to above, it is more safe to directly use end_ns in post processing.